### PR TITLE
Fix compiler warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Bad-Sky-Cab
 
 ## What it is
-An airborne sidescroller in a city of the future. Zoom past towering structures, avoid speeding delivery trucks and head onwards ever to the right!
+An airborne sidescroller in a city of the future. Zoom past towering structures, avoid speeding delivery trucks and head onwards ever to the right! Now in two flavors, vanilla javascript or rust+wasm.
 
 ## A quick history
 

--- a/rust-game/src/background.rs
+++ b/rust-game/src/background.rs
@@ -285,14 +285,6 @@ impl Building {
             building_type: building_types[type_idx].clone(),
         }
     }
-
-    pub fn update(&mut self, speed: f32) {
-        self.x -= speed;
-    }
-
-    pub fn is_off_screen(&self) -> bool {
-        self.x + self.width < -50.0
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
We fix compiler warnings by removing unused methods, and update the readme. 